### PR TITLE
Update llm_client.py

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -1,6 +1,6 @@
 from ollama import ChatResponse, GenerateResponse, chat, generate
 
-model_name = "llama3.2:1b"
+model_name = "llama3.2"
 
 PROMPT = "What is the capital of Italy?."
 


### PR DESCRIPTION
README instructs to pull 'llama3.2', but the script uses 'llama3.2:1b'. If only 'llama3.2' is pulled (which installs 'llama3.2:latest'), the script errors with "model not found".